### PR TITLE
default to bmp file to avoid encoder error

### DIFF
--- a/Scatto_continuo_v3/fileinfo.cpp
+++ b/Scatto_continuo_v3/fileinfo.cpp
@@ -2,7 +2,7 @@
 #include "win32api_wrap.h"
 #include <unordered_map>
 
-filename_c::filename_c() : filename_c("png") {}
+filename_c::filename_c() : filename_c("bmp") {}
 
 filename_c::filename_c(std::string && ext) : filename_c("caputure", std::move(ext)) {}
 


### PR DESCRIPTION
Depending on OpenCV build customization, encoding to formats other than BMP may not work.
